### PR TITLE
Fix toolPathFinder, remove unused vars

### DIFF
--- a/src/PhpGitHooks/Infrastructure/Tool/ToolPathFinder.php
+++ b/src/PhpGitHooks/Infrastructure/Tool/ToolPathFinder.php
@@ -4,21 +4,6 @@ namespace PhpGitHooks\Infrastructure\Tool;
 
 class ToolPathFinder
 {
-    const COMPOSER_VENDOR_DIR = '/../../../';
-    const COMPOSER_INSTALLED_FILE = 'composer/installed.json';
-
-    /** @var array */
-    private $tools = array(
-        'phpcs' => 'squizlabs/php_codesniffer',
-        'php-cs-fixer' => 'friendsofphp/php-cs-fixer',
-        'phpmd' => 'phpmd/phpmd',
-        'phpunit' => 'phpunit/phpunit',
-        'phpunit-randomizer' => 'fiunchinho/phpunit-randomizer',
-        'jsonlint' => 'seld/jsonlint',
-    );
-    /** @var array */
-    private $installedPackages = array();
-
     /**
      * @param string $tool
      *
@@ -26,15 +11,10 @@ class ToolPathFinder
      */
     public function find($tool)
     {
-        if (isset($this->installedPackages[$this->tools[$tool]])) {
-            $package = $this->installedPackages[$this->tools[$tool]];
-            foreach ($package['bin'] as $bin) {
-                if (preg_match("#${tool}$#", $bin)) {
-                    return dirname(__FILE__).self::COMPOSER_VENDOR_DIR.$package['name'].DIRECTORY_SEPARATOR.$bin;
-                }
-            }
+        $binToolPath = 'bin' . DIRECTORY_SEPARATOR . $tool;
+        if (is_dir('bin')) {
+            return $binToolPath;
         }
-
-        return 'bin'.DIRECTORY_SEPARATOR.$tool;
+        return 'vendor' . DIRECTORY_SEPARATOR . $binToolPath;
     }
 }


### PR DESCRIPTION
Fix error: "Could not open input file: bin/<toolname> on non-symfony projects.

Remove unused vars and code.